### PR TITLE
Fix VXLANs and ACL plugin, Implement DelPolicyRule

### DIFF
--- a/drivers/vppd/vppdriver.go
+++ b/drivers/vppd/vppdriver.go
@@ -745,6 +745,7 @@ func genNetworkVNI(netID string) uint32 {
 	h := fnv.New32a()
 	h.Write([]byte(netID))
 	vni := h.Sum32()
+	vni = vni & ((1 << 24) - 1)
 	if vni == 0 {
 		vni = 1
 	}

--- a/drivers/vppd/vppdriver.go
+++ b/drivers/vppd/vppdriver.go
@@ -617,6 +617,7 @@ func (d *VppDriver) AddPolicyRule(id string) error {
 	}
 
 	vppRule := &ruleCfg.OfnetPolicyRule
+	log.Infof("This is the rule: %+v", vppRule)
 	aclcfg := ACLConfig{}
 	var action *vpp_acl.AccessLists_Acl_Rule_Actions
 	var matches *vpp_acl.AccessLists_Acl_Rule_Matches
@@ -628,7 +629,7 @@ func (d *VppDriver) AddPolicyRule(id string) error {
 		}
 	} else if vppRule.Action == "deny" {
 		action = &vpp_acl.AccessLists_Acl_Rule_Actions{
-			AclAction: vpp_acl.AclAction_PERMIT,
+			AclAction: vpp_acl.AclAction_DENY,
 		}
 	}
 

--- a/drivers/vppd/vppdriver.go
+++ b/drivers/vppd/vppdriver.go
@@ -744,5 +744,9 @@ func (d *VppDriver) DelPolicyRule(id string) error {
 func genNetworkVNI(netID string) uint32 {
 	h := fnv.New32a()
 	h.Write([]byte(netID))
-	return h.Sum32()
+	vni := h.Sum32()
+	if vni == 0 {
+		vni = 1
+	}
+	return vni
 }

--- a/vendor/github.com/ligato/vpp-agent/plugins/defaultplugins/aclplugin/vppcalls/acl_vppcalls.go
+++ b/vendor/github.com/ligato/vpp-agent/plugins/defaultplugins/aclplugin/vppcalls/acl_vppcalls.go
@@ -168,7 +168,8 @@ func transformACLIpRules(rules []*acl.AccessLists_Acl_Rule) ([]acl_api.ACLRule, 
 				if err != nil {
 					return aclIPRules, err
 				}
-			} else if ipRule.Icmp != nil {
+			}
+			if ipRule.Icmp != nil {
 				aclRule = icmpACL(ipRule.Icmp, aclRule)
 			} else if ipRule.Tcp != nil {
 				aclRule = tcpACL(ipRule.Tcp, aclRule)

--- a/vendor/github.com/ligato/vpp-agent/plugins/defaultplugins/aclplugin/vppcalls/acl_vppcalls.go
+++ b/vendor/github.com/ligato/vpp-agent/plugins/defaultplugins/aclplugin/vppcalls/acl_vppcalls.go
@@ -175,7 +175,7 @@ func transformACLIpRules(rules []*acl.AccessLists_Acl_Rule) ([]acl_api.ACLRule, 
 				aclRule = tcpACL(ipRule.Tcp, aclRule)
 			} else if ipRule.Udp != nil {
 				aclRule = udpACL(ipRule.Udp, aclRule)
-			} else {
+			} else if ipRule.Ip == nil {
 				aclRule = otherACL(ipRule.Other, aclRule)
 			}
 			aclIPRules = append(aclIPRules, *aclRule)


### PR DESCRIPTION
What *I believe* still needs to be done in AddPolicyRule:

- policy rule operational state needs to be saved in the end, otherwise DelPolicyRule never gets called (netplugin complains that it cannot retrieve the state)
- new policy rule should probably result in new ACL for each group that uses the given policy
   - the reason is that for every ACL, ingress/engress interfaces have be set to afpackets of the associated network and the same policy may be used by multiple groups with different networks

